### PR TITLE
feature(one-per-line): One property per line

### DIFF
--- a/lib/rules/__tests__/array-bracket-one-per-line--invalid.js
+++ b/lib/rules/__tests__/array-bracket-one-per-line--invalid.js
@@ -1,0 +1,83 @@
+const rule = require('../array-bracket-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('array-bracket-one-per-line', rule, {
+  valid: [],
+  invalid: withParserOptions([
+    {
+      code: [
+        '[',
+        '  bar, baz,',
+        '  bip',
+        ']',
+      ].join('\n'),
+      output: [
+        '[',
+        '  bar, ',
+        'baz,',
+        '  bip',
+        ']',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All array elements should be on their own '
+          + 'line when the array spans multiple lines',
+        },
+      ],
+    },
+    {
+      code: [
+        '[{',
+        '  bar',
+        '}, baz,',
+        'bip]',
+      ].join('\n'),
+      output: [
+        '[{',
+        '  bar',
+        '}, ',
+        'baz,',
+        'bip',
+        ']',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All array elements should be on their own '
+          + 'line when the array spans multiple lines',
+        },
+        {
+          message: 'Expected line break before this bracket',
+        },
+      ],
+    },
+    {
+      code: [
+        '[',
+        '  bar, baz, function() {',
+        '  }',
+        ']',
+      ].join('\n'),
+      output: [
+        '[',
+        '  bar, ',
+        'baz, ',
+        'function() {',
+        '  }',
+        ']',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All array elements should be on their own '
+          + 'line when the array spans multiple lines',
+        },
+        {
+          message: 'All array elements should be on their own '
+          + 'line when the array spans multiple lines',
+        },
+      ],
+    },
+  ], [{ onePerLine: true }]),
+});
+

--- a/lib/rules/__tests__/array-bracket-one-per-line--valid.js
+++ b/lib/rules/__tests__/array-bracket-one-per-line--valid.js
@@ -1,0 +1,59 @@
+const rule = require('../array-bracket-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('array-bracket-one-per-line', rule, {
+  valid: withParserOptions([
+    { code: '[]' },
+    { code: '[bar]' },
+    { code: '[bar, baz]' },
+    {
+      code: [
+        '[',
+        '  bar, baz',
+        ']',
+      ].join('\n'),
+    },
+    {
+      code: [
+        '[',
+        '  bar,',
+        '  baz',
+        ']',
+      ].join('\n'),
+    },
+    {
+      code: [
+        '[bar, {',
+        '  baz',
+        '}]',
+      ].join('\n'),
+    },
+    {
+      code: [
+        '[bar, {',
+        '  baz',
+        '}, this]',
+      ].join('\n'),
+    },
+    {
+      code: [
+        '[bar, {',
+        '  baz',
+        '}, {',
+        ' bip',
+        '}]',
+      ].join('\n'),
+    },
+    {
+      code: [
+        '[{',
+        '  bar',
+        '}, baz]',
+      ].join('\n'),
+    },
+  ], [{ onePerLine: true }]),
+  invalid: [],
+});
+

--- a/lib/rules/__tests__/call-parens-one-per-line--invalid.js
+++ b/lib/rules/__tests__/call-parens-one-per-line--invalid.js
@@ -1,0 +1,81 @@
+const rule = require('../call-parens-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('call-parens-one-per-line', rule, {
+  valid: [],
+  invalid: withParserOptions([
+    {
+      code: [
+        'foo(',
+        '  bar, baz,',
+        '  bip',
+        ')',
+      ].join('\n'),
+      output: [
+        'foo(',
+        '  bar, ',
+        'baz,',
+        '  bip',
+        ')',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All arguments should be on their '
+          + 'own line in a multiline function call',
+        },
+      ],
+    },
+    {
+      code: [
+        'foo({',
+        '  bar',
+        '}, baz,',
+        'bip',
+        ')',
+      ].join('\n'),
+      output: [
+        'foo({',
+        '  bar',
+        '}, ',
+        'baz,',
+        'bip',
+        ')',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All arguments should be on their '
+          + 'own line in a multiline function call',
+        },
+      ],
+    },
+    {
+      code: [
+        'foo(',
+        '  bar, baz, function() {',
+        '  }',
+        ')',
+      ].join('\n'),
+      output: [
+        'foo(',
+        '  bar, ',
+        'baz, ',
+        'function() {',
+        '  }',
+        ')',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All arguments should be on their '
+          + 'own line in a multiline function call',
+        },
+        {
+          message: 'All arguments should be on their '
+          + 'own line in a multiline function call',
+        },
+      ],
+    },
+  ], [{ onePerLine: true }]),
+});
+

--- a/lib/rules/__tests__/call-parens-one-per-line--valid.js
+++ b/lib/rules/__tests__/call-parens-one-per-line--valid.js
@@ -1,0 +1,72 @@
+const rule = require('../call-parens-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('call-parens-one-per-line', rule, {
+  valid: withParserOptions([
+    { code: 'foo()' },
+    { code: 'foo(bar)' },
+    { code: 'foo(bar, baz)' },
+    {
+      code: [
+        'foo(',
+        '  bar, baz',
+        ')',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'foo(',
+        '  bar,',
+        '  baz',
+        ')',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'foo(bar, {',
+        '  baz',
+        '})',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'foo(bar, {',
+        '  baz',
+        '}, this)',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'foo(bar, {',
+        '  baz',
+        '}, {',
+        ' bip',
+        '})',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'foo({',
+        '  bar',
+        '}, baz)',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'then(result => {',
+        '}, err => {',
+        '})',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'then(result => {',
+        '}, errorHandler)',
+      ].join('\n'),
+    },
+  ], [{ onePerLine: true }]),
+  invalid: [],
+});
+

--- a/lib/rules/__tests__/func-parens-one-per-line--invalid.js
+++ b/lib/rules/__tests__/func-parens-one-per-line--invalid.js
@@ -1,0 +1,32 @@
+const rule = require('../func-parens-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('call-parens-one-per-line', rule, {
+  valid: [],
+  invalid: withParserOptions([
+    {
+      code: [
+        'function foo(',
+        '  bar, baz,',
+        '  bip',
+        ') {}',
+      ].join('\n'),
+      output: [
+        'function foo(',
+        '  bar, ',
+        'baz,',
+        '  bip',
+        ') {}',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All parameters should be on their own '
+          + 'line when a function definition spans multiple lines',
+        },
+      ],
+    },
+  ], [{ onePerLine: true }]),
+});
+

--- a/lib/rules/__tests__/func-parens-one-per-line--valid.js
+++ b/lib/rules/__tests__/func-parens-one-per-line--valid.js
@@ -1,0 +1,29 @@
+const rule = require('../func-parens-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('call-parens-one-per-line', rule, {
+  valid: withParserOptions([
+    { code: 'function foo() {}' },
+    { code: 'function foo(bar) {}' },
+    { code: 'function foo(bar, baz) {}' },
+    {
+      code: [
+        'function foo(',
+        '  bar, baz',
+        ') {}',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'function foo(',
+        '  bar,',
+        '  baz',
+        ') {}',
+      ].join('\n'),
+    },
+  ], [{ onePerLine: true }]),
+  invalid: [],
+});
+

--- a/lib/rules/__tests__/object-curly-one-per-line--invalid.js
+++ b/lib/rules/__tests__/object-curly-one-per-line--invalid.js
@@ -1,0 +1,58 @@
+const rule = require('../object-curly-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('object-curly-one-per-line', rule, {
+  valid: [],
+  invalid: withParserOptions([
+    {
+      code: [
+        'let foo = {',
+        '  bar, baz,',
+        '  bip',
+        '}',
+      ].join('\n'),
+      output: [
+        'let foo = {',
+        '  bar, ',
+        'baz,',
+        '  bip',
+        '}',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All object properties should be on their own '
+          + 'line when the object definition spans multiple lines',
+        },
+      ],
+    },
+    {
+      code: [
+        'let foo = {',
+        '  bar, baz, foo: function() {',
+        '  }',
+        '}',
+      ].join('\n'),
+      output: [
+        'let foo = {',
+        '  bar, ',
+        'baz, ',
+        'foo: function() {',
+        '  }',
+        '}',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'All object properties should be on their own '
+          + 'line when the object definition spans multiple lines',
+        },
+        {
+          message: 'All object properties should be on their own '
+          + 'line when the object definition spans multiple lines',
+        },
+      ],
+    },
+  ], [{ onePerLine: true }]),
+});
+

--- a/lib/rules/__tests__/object-curly-one-per-line--valid.js
+++ b/lib/rules/__tests__/object-curly-one-per-line--valid.js
@@ -1,0 +1,29 @@
+const rule = require('../object-curly-newline');
+const { RuleTester } = require('eslint');
+const { withParserOptions } = require('../../test-utils');
+
+const ruleTester = new RuleTester();
+ruleTester.run('object-curly-one-per-line', rule, {
+  valid: withParserOptions([
+    { code: '{}' },
+    { code: '{bar}' },
+    { code: '{bar, baz}' },
+    {
+      code: [
+        '{',
+        '  bar, baz',
+        '}',
+      ].join('\n'),
+    },
+    {
+      code: [
+        '{',
+        '  bar,',
+        '  baz',
+        '}',
+      ].join('\n'),
+    },
+  ], [{ onePerLine: true }]),
+  invalid: [],
+});
+

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -1,6 +1,10 @@
 const groupBy = require('lodash/groupBy');
 const last = require('lodash/last');
-const { isValidOpeningPunc, isValidClosingPunc } = require('../utils');
+const {
+  isValidOpeningPunc,
+  isValidClosingPunc,
+  validateOnePerLine,
+} = require('../utils');
 
 module.exports = {
   meta: {
@@ -9,6 +13,11 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    let onePerLine = false;
+
+    if (context.options.length) {
+      onePerLine = context.options[0] && context.options[0].onePerLine;
+    }
 
     function check(node) {
       const { elements, loc } = node;
@@ -40,6 +49,18 @@ module.exports = {
           message: 'Expected line break before this bracket',
           fix: fixer => fixer.insertTextBefore(closingBracket, '\n'),
         });
+      }
+
+
+      if (onePerLine) {
+        validateOnePerLine(
+          node.loc.start.line,
+          node.loc.end.line,
+          elements,
+          context,
+          'All array elements should be on their own line '
+          + 'when the array spans multiple lines'
+        );
       }
     }
 

--- a/lib/rules/call-parens-newline.js
+++ b/lib/rules/call-parens-newline.js
@@ -1,6 +1,10 @@
 const groupBy = require('lodash/groupBy');
 const last = require('lodash/last');
-const { isValidOpeningPunc, isValidClosingPunc } = require('../utils');
+const {
+  isValidOpeningPunc,
+  isValidClosingPunc,
+  validateOnePerLine,
+} = require('../utils');
 
 module.exports = {
   meta: {
@@ -9,6 +13,11 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    let onePerLine = false;
+
+    if (context.options.length) {
+      onePerLine = context.options[0] && context.options[0].onePerLine;
+    }
 
     function check(node) {
       const args = node.arguments;
@@ -46,6 +55,17 @@ module.exports = {
           message: 'Expected line break before this paren',
           fix: fixer => fixer.insertTextBefore(closingParen, '\n'),
         });
+      }
+
+      if (onePerLine) {
+        validateOnePerLine(
+          node.callee.loc.end.line,
+          node.loc.end.line,
+          args,
+          context,
+          'All arguments should be on their own line '
+          + 'in a multiline function call'
+        );
       }
     }
 

--- a/lib/rules/func-parens-newline.js
+++ b/lib/rules/func-parens-newline.js
@@ -1,6 +1,10 @@
 const groupBy = require('lodash/groupBy');
 const last = require('lodash/last');
-const { isValidOpeningPunc, isValidClosingPunc } = require('../utils');
+const {
+  isValidOpeningPunc,
+  isValidClosingPunc,
+  validateOnePerLine,
+} = require('../utils');
 
 module.exports = {
   meta: {
@@ -9,6 +13,11 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    let onePerLine = false;
+
+    if (context.options.length) {
+      onePerLine = context.options[0] && context.options[0].onePerLine;
+    }
 
     function check(node) {
       const { params } = node;
@@ -51,6 +60,17 @@ module.exports = {
           message: 'Expected line break before this paren',
           fix: fixer => fixer.insertTextBefore(closingParen, '\n'),
         });
+      }
+
+      if (onePerLine) {
+        validateOnePerLine(
+          openingParen.loc.start.line,
+          closingParen.loc.end.line,
+          params,
+          context,
+          'All parameters should be on their own line '
+          + 'when a function definition spans multiple lines'
+        );
       }
     }
 

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -1,4 +1,5 @@
 const last = require('lodash/last');
+const { validateOnePerLine } = require('../utils');
 
 module.exports = {
   meta: {
@@ -7,6 +8,12 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    let onePerLine = false;
+
+    if (context.options.length) {
+      onePerLine = context.options[0] && context.options[0].onePerLine;
+    }
+
 
     function check(node) {
       const { properties, loc } = node;
@@ -33,6 +40,17 @@ module.exports = {
           message: 'Expected line break before this brace',
           fix: fixer => fixer.insertTextBefore(closingBrace, '\n'),
         });
+      }
+
+      if (onePerLine) {
+        validateOnePerLine(
+          node.loc.start.line,
+          node.loc.end.line,
+          properties,
+          context,
+          'All object properties should be on their own line '
+          + 'when the object definition spans multiple lines'
+        );
       }
     }
 

--- a/lib/test-utils.js
+++ b/lib/test-utils.js
@@ -6,9 +6,10 @@ const parserOptions = {
   ecmaVersion: 2017,
 };
 
-exports.withParserOptions = function withParserOptions(testCases) {
+exports.withParserOptions = function withParserOptions(testCases, options) {
   testCases.forEach(testCase => {
     testCase.parserOptions = parserOptions;
+    testCase.options = options;
   });
 
   return testCases;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,3 +18,47 @@ exports.isValidClosingPunc = function isValidClosingPunc(token) {
 exports.isValidOpeningPunc = function isValidOpeningPunc(token) {
   return token.type === 'Punctuator' && validOpeningPuncs[token.value];
 };
+
+exports.validateOnePerLine = function validateOnePerLine(
+  startLine, endLine, props, context, message
+) {
+  let hasSingleLineArg = false;
+  let previousProp;
+  let currentProp;
+
+  // If it's not more than 3 lines total, it can't be invalid.
+  // The other rules will catch it.
+  if (endLine - startLine <= 2) {
+    return;
+  }
+
+  for (let i = 0; i < props.length; i++) {
+    currentProp = props[i];
+
+    const isSingleLine =
+      currentProp.loc.start.line === currentProp.loc.end.line;
+    const isFirstLine = currentProp.loc.start.line === startLine;
+    const isLastLine = currentProp.loc.end.line === endLine;
+    const isSameLineAsPrevious =
+      previousProp && previousProp.loc.end.line === currentProp.loc.start.line;
+
+    if (isSingleLine && !isFirstLine && !isLastLine) {
+      hasSingleLineArg = true;
+    }
+
+    if (
+      hasSingleLineArg
+      && isSameLineAsPrevious
+      && !isFirstLine
+      && !isLastLine
+    ) {
+      context.report({
+        loc: currentProp.loc.start,
+        message,
+        fix: fixer => fixer.insertTextBefore(currentProp, '\n'),
+      });
+    }
+
+    previousProp = currentProp;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-brackets",
   "version": "0.0.1",
   "description": "ESLint style rules for minimizing diffs with line breaks around brackets",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "scripts": {
     "build": "npm run clean && babel lib -d dist",
     "clean": "rimraf coverage dist",


### PR DESCRIPTION
Adds a `onePerLine` option to the rules that it makes sense for (Conditionals don't really have clearly defined lists of params, but a tree of expressions, which makes it difficult to come up with a rule to enforce here).

### Function Definitions

```javascript
// valid

function foo(bar, baz) {}

function foo(
  bar, baz
) {}

function foo(
  bar,
  baz
) {}

// invalid

function foo(bar
  baz) {}

function foo(
  bar, baz
  qux
) {}

```

### Function Calls

```javascript
// valid

foo(bar, baz);

foo(bar, baz, function() {

});

foo(bar, function() {

}, baz);

foo(function() {

}, bar, baz);

foo(bar, baz, {

}, {

});

foo (
  bar, baz
);

foo (
  bar, 
  baz,
  function() {

  }
);

// invalid

foo(bar, 
  baz);

foo(
  bar, baz, function() {

  }
);

foo(
  bar, baz
  qux, 
);
```

### Object Declaration

```javascript
// valid

const foo = { bar, baz };

const foo = {
  bar, baz
};

const foo = {
  bar, 
  baz
};

const foo = {
  bar: { baz }
};

const foo = {
  bar: [
    baz
  ],
  qux: {

  }
};

// invalid

const foo = { bar, 
  baz };

const foo = {
  bar, baz,
  qux
};

const foo = { bar: {
  baz
} };
```

### Array Declaration

```javascript
// valid

const foo = [ bar, baz ];

const foo = [
  bar, baz
];

const foo = [
  bar, 
  baz
];

const foo = [
  [ baz ]
];

const foo = [
  [
    baz
  ],
  {
    qux
  }
];

// invalid

const foo = [ bar, 
  baz ];

const foo = [
  bar, baz,
  qux
];
```