### PR TITLE
feat(templates): Allows templates to begin/end lines

### DIFF
--- a/lib/rules/__tests__/array-bracket-newline--invalid.js
+++ b/lib/rules/__tests__/array-bracket-newline--invalid.js
@@ -94,22 +94,6 @@ ruleTester.run('array-bracket-newline', rule, {
     },
     {
       code: [
-        '[/* test */`(',
-        ')`]',
-      ].join('\n'),
-      output: [
-        '[',
-        '/* test */`(',
-        ')`',
-        ']',
-      ].join('\n'),
-      errors: [
-        { message: 'Expected line break after this bracket' },
-        { message: 'Expected line break before this bracket' },
-      ],
-    },
-    {
-      code: [
         '["long line" +',
         ' "oh really?"]',
       ].join('\n'),

--- a/lib/rules/__tests__/call-parens-one-per-line--valid.js
+++ b/lib/rules/__tests__/call-parens-one-per-line--valid.js
@@ -66,6 +66,13 @@ ruleTester.run('call-parens-one-per-line', rule, {
         '}, errorHandler)',
       ].join('\n'),
     },
+    {
+      code: [
+        'foo(hbs`',
+        '  {{template}}',
+        '`, baz)',
+      ].join('\n'),
+    },
   ], [{ onePerLine: true }]),
   invalid: [],
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,11 +12,15 @@ const validOpeningPuncs = {
 };
 
 exports.isValidClosingPunc = function isValidClosingPunc(token) {
-  return token.type === 'Template' || (token.type === 'Punctuator' && validClosingPuncs[token.value]);
+  return token.type === 'Template' || (
+    token.type === 'Punctuator' && validClosingPuncs[token.value]
+  );
 };
 
 exports.isValidOpeningPunc = function isValidOpeningPunc(token) {
-  return token.type === 'Template' || (token.type === 'Punctuator' && validOpeningPuncs[token.value]);
+  return token.type === 'Template' || (
+    token.type === 'Punctuator' && validOpeningPuncs[token.value]
+  );
 };
 
 exports.validateOnePerLine = function validateOnePerLine(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,11 +12,11 @@ const validOpeningPuncs = {
 };
 
 exports.isValidClosingPunc = function isValidClosingPunc(token) {
-  return token.type === 'Punctuator' && validClosingPuncs[token.value];
+  return token.type === 'Template' || (token.type === 'Punctuator' && validClosingPuncs[token.value]);
 };
 
 exports.isValidOpeningPunc = function isValidOpeningPunc(token) {
-  return token.type === 'Punctuator' && validOpeningPuncs[token.value];
+  return token.type === 'Template' || (token.type === 'Punctuator' && validOpeningPuncs[token.value]);
 };
 
 exports.validateOnePerLine = function validateOnePerLine(


### PR DESCRIPTION
This PR allows templates to begin or end lines, which makes sense in a variety of use cases:

```js
render(hbs`
  <div>
    {{template}}
  </div>
`);
```